### PR TITLE
add whitespace to comply with standard

### DIFF
--- a/test/lib/flac.js
+++ b/test/lib/flac.js
@@ -1,6 +1,6 @@
-/*eslint-disable no-undef*/ // oh eslint
+/* eslint-disable no-undef */ // oh eslint
 var Promise = require('bluebird')
-/*eslint-enable no-undef*/
+/* eslint-enable no-undef */
 var promisify = Promise.promisify
 
 var createReadStream = require('fs').createReadStream

--- a/test/lib/metadata.js
+++ b/test/lib/metadata.js
@@ -1,6 +1,6 @@
-/*eslint-disable no-undef*/ // oh eslint
+/* eslint-disable no-undef */ // oh eslint
 var Promise = require('bluebird')
-/*eslint-enable no-undef*/
+/* eslint-enable no-undef */
 var promisify = Promise.promisify
 
 var path = require('path')

--- a/test/lib/zip.js
+++ b/test/lib/zip.js
@@ -1,6 +1,6 @@
-/*eslint-disable no-undef*/ // oh eslint
+/* eslint-disable no-undef */ // oh eslint
 var Promise = require('bluebird')
-/*eslint-enable no-undef*/
+/* eslint-enable no-undef */
 
 var createWriteStream = require('fs').createWriteStream
 var path = require('path')

--- a/test/unpack.js
+++ b/test/unpack.js
@@ -1,6 +1,6 @@
-/*eslint-disable no-undef*/ // oh eslint
+/* eslint-disable no-undef */ // oh eslint
 var Promise = require('bluebird')
-/*eslint-enable no-undef*/
+/* eslint-enable no-undef */
 var promisify = Promise.promisify
 
 var join = require('path').join

--- a/test/utils-zip.js
+++ b/test/utils-zip.js
@@ -1,6 +1,6 @@
-/*eslint-disable no-undef*/ // oh eslint
+/* eslint-disable no-undef */ // oh eslint
 var Promise = require('bluebird')
-/*eslint-enable no-undef*/
+/* eslint-enable no-undef */
 var promisify = Promise.promisify
 
 var join = require('path').join


### PR DESCRIPTION
[d623296](https://github.com/feross/standard/commit/d623296935a1c4046c17005163ff1abb4b3241b5) disabled the test for this repo since it started complaining about the whitespace in the comment.

This patch fixes that so that packard can be added back to the list of tested modules.
